### PR TITLE
Fix bugs #3, #4.

### DIFF
--- a/CodicExtension/CodicExtension.csproj
+++ b/CodicExtension/CodicExtension.csproj
@@ -102,7 +102,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="CodicExtension.ruleset" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -117,6 +119,7 @@
       <HintPath>..\packages\VSSDK.DTE.7.0.4\lib\net20\envdte.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\VSSDK.CoreUtility.12.0.4\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
       <Private>True</Private>

--- a/CodicExtension/Presentation/QuickLookDialog.xaml.cs
+++ b/CodicExtension/Presentation/QuickLookDialog.xaml.cs
@@ -210,7 +210,8 @@ namespace CodicExtension.Presentation
 
             Deactivated += (sender, args) =>
             {
-                Close();
+                // Cannot call 'Close()' directly from window event handler.
+                Dispatcher.BeginInvoke((Action)(() => Close()));
             };
 
             // Handing of ESC key.

--- a/CodicExtension/packages.config
+++ b/CodicExtension/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.VSSDK.BuildTools" version="14.1.24720" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
ウィンドウ Deactivate 時に イベントハンドラー内で Close() をコールする際 InvalidOperationException が発生していたため、これを修正しました。
Issues #3, #4 の現象はこれで解決するかもしれません。

また、単語データ一覧機能の実装を心待ちにしております！
